### PR TITLE
Delete publish output & other improvements

### DIFF
--- a/src/dotnet-purge/Program.cs
+++ b/src/dotnet-purge/Program.cs
@@ -177,6 +177,7 @@ static class DotnetCli
         // Get configurations first
         var configurations = (await GetProperties(null, [ProjectProperties.Configurations]))[ProjectProperties.Configurations]
             .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
         var result = new Dictionary<string, Dictionary<string, string>>();
 
         foreach (var configuration in configurations)
@@ -191,7 +192,7 @@ static class DotnetCli
     public static async Task<Dictionary<string, string>> GetProperties(string? configuration, IEnumerable<string> properties)
     {
         var propertiesValue = string.Join(',', properties);
-        string[] arguments = ["msbuild", $"-getProperty:{propertiesValue}"];
+        string[] arguments = ["msbuild", $"-getProperty:{propertiesValue}", "-p:BuildProjectReferences=false"];
         if (configuration is not null)
         {
             arguments = [.. arguments, $"-p:Configuration={configuration}"];

--- a/src/dotnet-purge/Program.cs
+++ b/src/dotnet-purge/Program.cs
@@ -54,14 +54,14 @@ static async Task PurgeProject(string dir)
             foreach (var framework in targetFrameworks)
             {
                 Write($"Running '{dir}{Path.DirectorySeparatorChar}dotnet clean --configuration {configuration} --framework {framework}'...");
-                await DotnetCli.Clean(["--configuration", configuration, "--framework", framework]);
+                await DotnetCli.Clean(["--configuration", configuration, "--framework", framework, "-p:BuildProjectReferences=false"]);
                 WriteLine(" done!", ConsoleColor.Green);
             }
         }
         else
         {
             Write($"Running '{dir}{Path.DirectorySeparatorChar}dotnet clean --configuration {configuration}'...");
-            await DotnetCli.Clean(["--configuration", configuration]);
+            await DotnetCli.Clean(["--configuration", configuration, "-p:BuildProjectReferences=false"]);
             WriteLine(" done!", ConsoleColor.Green);
         }
     }

--- a/src/dotnet-purge/dotnet-purge.csproj
+++ b/src/dotnet-purge/dotnet-purge.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-purge</ToolCommandName>
-    <VersionPrefix>0.0.4</VersionPrefix>
+    <VersionPrefix>0.0.5</VersionPrefix>
     <!--<VersionSuffix>pre</VersionSuffix>-->
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Ensures that publish and package output are deleted and changes some ordering and adds some extra flags to ensure that more output content is deleted.

Contributes to #6 