### PR TITLE
Fix empty output dir value

### DIFF
--- a/src/dotnet-purge/Program.cs
+++ b/src/dotnet-purge/Program.cs
@@ -170,13 +170,14 @@ static async Task PurgeProject(string dir, bool noClean)
     // Delete the output directories for each configuration
     foreach (var key in properties.Keys)
     {
-        var (configuration, targetFramework) = key;
+        var (configuration, _) = key;
         var outputDirs = properties[key];
 
         // Get the output directories paths
         var dirsToDelete = outputDirs.Values.ToList();
 
         var pathsToDelete = dirsToDelete
+            .Where(d => !string.IsNullOrEmpty(d))
             .Select(d => Path.GetFullPath(d, DotnetCli.WorkingDirectory))
             .Where(d => Directory.Exists(d))
             .OrderDescending()
@@ -185,7 +186,7 @@ static async Task PurgeProject(string dir, bool noClean)
         // Delete the output directories
         foreach (var dirPath in pathsToDelete)
         {
-            if (Directory.Exists(dirPath))
+            if (Directory.Exists(dirPath) && !string.Equals(dir, dirPath, StringComparison.Ordinal))
             {
                 Directory.Delete(dirPath, recursive: true);
                 WriteLine($"Deleted '{dirPath}'");

--- a/src/dotnet-purge/dotnet-purge.csproj
+++ b/src/dotnet-purge/dotnet-purge.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-purge</ToolCommandName>
-    <VersionPrefix>0.0.8</VersionPrefix>
+    <VersionPrefix>0.0.9</VersionPrefix>
     <!--<VersionSuffix>pre</VersionSuffix>-->
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Handle case when an output dir property value is empty which resulted in the project directory itself being deleted!

Hopefully fixes this: https://github.com/DamianEdwards/dotnet-purge/issues/10#issuecomment-2708810424