### PR TITLE
Handle cancellation & add error handling

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/dotnet-purge/dotnet-purge.csproj
+++ b/src/dotnet-purge/dotnet-purge.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-purge</ToolCommandName>
-    <VersionPrefix>0.0.10</VersionPrefix>
+    <VersionPrefix>0.0.11</VersionPrefix>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>


### PR DESCRIPTION
Can now Ctrl+C the process and it will gracefully handle the cancellation request and report the results. Also added some error handling so that exceptions when purging one project don't crash the whole process. It prints the error and continues on right now but logged #28 to track adding an option to allow controlling continuation behavior.

Fixes #17
Fixes #23