### PR TITLE
Use project file paths instead of directory

### DIFF
--- a/src/dotnet-purge/Program.cs
+++ b/src/dotnet-purge/Program.cs
@@ -68,7 +68,7 @@ async Task<int> PurgeCommand(ParseResult parseResult, CancellationToken cancella
     WriteLine($"Found {projectCount} projects to purge");
     WriteLine();
 
-    if (projectCount == 0)
+    if (projectCount == 0 && !recurseValue)
     {
         WriteLine("Use --recurse to search for projects in sub-directories.", ConsoleColor.DarkBlue);
     }

--- a/src/dotnet-purge/dotnet-purge.csproj
+++ b/src/dotnet-purge/dotnet-purge.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-purge</ToolCommandName>
-    <VersionPrefix>0.0.11</VersionPrefix>
+    <VersionPrefix>0.0.12</VersionPrefix>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>

--- a/tests/testprojects/ConsoleApp1/ConsoleApp1.csproj
+++ b/tests/testprojects/ConsoleApp1/ConsoleApp1.csproj
@@ -8,4 +8,8 @@
     <PublishAot>True</PublishAot>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary1\ClassLibrary1.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/testprojects/EmptyWeb1/EmptyWeb1.csproj
+++ b/tests/testprojects/EmptyWeb1/EmptyWeb1.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\RazorClassLibrary1\RazorClassLibrary1.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Update logic to use project file paths instead of project directory paths
- Print a message suggesting to use `--recurse` option if no projects found to purge
- Use relative paths when printing paths instead of full paths
- Count cancelled projects properly

Fixes #21 