### PR TITLE
Add --vs option & handle target being dir or file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ dotnet tool install -g dotnet-purge
 ## Usage
 
 ```bash
-dotnet-purge [<TARGETDIR>] [options]
+dotnet-purge [<TARGET>] [options]
 ```
 
 ### Arguments
 
 Name  | Description
 ------|------------------------------------------------
-&lt;TARGETDIR&gt;  |The directory that contains the solution or project file to purge. If not specified, the current directory will be used.
+&lt;TARGET&gt; | The path of the solution or project to purge. If not specified, the current directory will be used.
 
 ### Options
 
@@ -29,6 +29,7 @@ Name  | Description
 --version | Show version information
 -r, --recurse | Find projects in sub-directories and purge those too.
 -n, --no-clean | Don't run `dotnet clean` before deleting the output directories.
+--vs | Delete temporary files & directories created by Visual Studio, e.g. .vs, *.csproj.user.
 
 ### Examples
 
@@ -37,13 +38,17 @@ Purge the solution/project in the current directory:
 ```bash
 ~/src/MyProject
 $ dotnet purge
-Running '/home/damian/src/MyProject/dotnet clean --configuration Debug --framework net8.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Debug --framework net9.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Release --framework net8.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Release --framework net9.0'... done!
-Deleted '/home/damian/src/MyProject/obj/'
-Deleted '/home/damian/src/MyProject/bin/Debug'
-Deleted '/home/damian/src/MyProject/bin/'
+Found 1 project to purge
+
+Running 'dotnet clean ./MyProject.csproj --configuration Debug --framework net8.0'... done!
+Running 'dotnet clean ./MyProject.csproj --configuration Debug --framework net9.0'... done!
+Running 'dotnet clean ./MyProject.csproj --configuration Release --framework net8.0'... done!
+Running 'dotnet clean ./MyProject.csproj --configuration Release --framework net9.0'... done!
+Deleted './obj/'
+Deleted './bin/Debug'
+Deleted './bin/'
+
+Finished purging 1 project
 ```
 
 Purge the solution/project in the specified directory:
@@ -51,13 +56,46 @@ Purge the solution/project in the specified directory:
 ```bash
 ~/src
 $ dotnet purge ./MyProject
-Running '/home/damian/src/MyProject/dotnet clean --configuration Debug --framework net8.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Debug --framework net9.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Release --framework net8.0'... done!
-Running '/home/damian/src/MyProject/dotnet clean --configuration Release --framework net9.0'... done!
-Deleted '/home/damian/src/MyProject/obj/'
-Deleted '/home/damian/src/MyProject/bin/Debug'
-Deleted '/home/damian/src/MyProject/bin/'
+Found 1 project to purge
+
+Running 'dotnet clean ./MyProject/MyProject.csproj --configuration Debug --framework net8.0'... done!
+Running 'dotnet clean ./MyProject/MyProject.csproj  --configuration Debug --framework net9.0'... done!
+Running 'dotnet clean ./MyProject/MyProject.csproj  --configuration Release --framework net8.0'... done!
+Running 'dotnet clean ./MyProject/MyProject.csproj  --configuration Release --framework net9.0'... done!
+Deleted './MyProject/obj/'
+Deleted './MyProject/bin/Debug'
+Deleted './MyProject/bin/'
+(1/2) Purged ./MyProject/MyProject.csproj
+
+Finished purging 1 project
+```
+
+Purge the specified solution:
+
+```bash
+~/src
+$ dotnet purge ./MySolution/MySolution.slnx --vs
+Found 2 projects to purge
+
+Running 'dotnet clean ./MySolution/MyProject/MyProject.csproj --configuration Debug --framework net8.0'... done!
+Running 'dotnet clean ./MySolution/MyProject/MyProject.csproj --configuration Debug --framework net9.0'... done!
+Running 'dotnet clean ./MySolution/MyProject/MyProject.csproj --configuration Release --framework net8.0'... done!
+Running 'dotnet clean ./MySolution/MyProject/MyProject.csproj --configuration Release --framework net9.0'... done!
+Deleted './MySolution/MyProject/obj/'
+Deleted './MySolution/MyProject/bin/Debug'
+Deleted './MySolution/MyProject/bin/'
+Deleted './MySolution/MyProject/.vs'
+Deleted './MySolution/MyProject/MyProject.csproj.user'
+(1/2) Purged ./MySolution/MyProject/MyProject.csproj
+Running 'dotnet clean ./MySolution/MyLibrary/MyLibrary.csproj --configuration Debug --framework net8.0'... done!
+Running 'dotnet clean ./MySolution/MyLibrary/MyLibrary.csproj --configuration Release --framework net8.0'... done!
+Deleted './MySolution/MyLibrary/obj/'
+Deleted './MySolution/MyLibrary/bin/Debug'
+Deleted './MySolution/MyLibrary/bin/'
+Deleted './MySolution/MyLibrary/.vs'
+(2/2) Purged ./MySolution/MyLibrary/MyLibrary.csproj
+
+Finished purging 2 projects
 ```
 
 ## Add to Windows Explorer


### PR DESCRIPTION
Add `--vs` option to delete Visual Studio related assets.
Handle the passed target path being to a directory or a specific solution or project file path.

Fixes #27 