### PR TITLE
Fix issues with csproj files where <TargetFrameworks>.net10.0</TargetFrameworks>

### DIFF
--- a/src/dotnet-purge/Program.cs
+++ b/src/dotnet-purge/Program.cs
@@ -2,11 +2,13 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using NuGet.Versioning;
 using Spectre.Console;
@@ -645,7 +647,17 @@ static class DotnetCli
         {
             targetFrameworks = value.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         }
-        var isMultiTargeted = targetFrameworks?.Length > 1;
+        
+        var isMultiTargeted = targetFrameworks?.Length >= 1;
+        
+        // Alternative. Solution. The issue with targetFrameworks only appears to happen if it's .net 10.
+        // So instead of Length >= 1. We could revert back to Length > 1 and do something like below
+        // Regex netVersionRegex = new Regex("^net(?<version>\\d+\\.0)$");
+        // if (targetFrameworks is {Length: 1} && netVersionRegex.Match(targetFrameworks[0]) is {Success: true} match)
+        // {
+        //     var version = double.Parse(match.Groups["version"].Value, CultureInfo.InvariantCulture);
+        //     isMultiTargeted = version >= 10.0;
+        // }
 
         var result = new Dictionary<(string Configuration, string? TargetFramework), Dictionary<string, string>>();
 


### PR DESCRIPTION
I ran into an error like this when trying to purge a project where TargetFrameworks was set to a single net10.0 value. See example attachment. Note that the error occurs if it is .net10.0. I could not produce it on earlier version like for instance net9.0.

I have added two solution suggestions. 

1. A very low practical version instead of checking for more than 1 targetframework we check for 1 or more. I don't know if this might cause other issues. 
2. Commented out. But we check if there is only one targetframework and if it's .net 10 or larger in which case we set the isMultiTargeted to true

This was the error

```text
Unhandled exception: System.ArgumentException: The path is empty. (Parameter 'path')
   at System.IO.Path.GetFullPath(String path)
   at System.IO.DirectoryInfo..ctor(String path)
   at Program.<<Main>$>g__DeleteEmptyParentDirectories|0_6(String path, String targetPath, Boolean dryRun) in D:\src\GitHub\DamianEdwards\dotnet-purge\src\dotnet-purge\Program.cs:line 546
   at Program.<>c__DisplayClass0_1.<<<Main>$>b__10>d.MoveNext() in D:\src\GitHub\DamianEdwards\dotnet-purge\src\dotnet-purge\Program.cs:line 362
--- End of stack trace from previous location ---
   at Spectre.Console.Status.<>c__DisplayClass16_0.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/Status/Status.cs:line 79
--- End of stack trace from previous location ---
   at Spectre.Console.Status.<>c__DisplayClass17_0`1.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/Status/Status.cs:line 120
--- End of stack trace from previous location ---
   at Spectre.Console.Progress.<>c__DisplayClass32_0`1.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 138
--- End of stack trace from previous location ---
   at Spectre.Console.Internal.DefaultExclusivityMode.RunAsync[T](Func`1 func) in /_/src/Spectre.Console/Internal/DefaultExclusivityMode.cs:line 40
   at Spectre.Console.Progress.StartAsync[T](Func`2 action) in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 121
   at Spectre.Console.Status.StartAsync[T](String status, Func`2 func) in /_/src/Spectre.Console/Live/Status/Status.cs:line 117
   at Spectre.Console.Status.StartAsync(String status, Func`2 action) in /_/src/Spectre.Console/Live/Status/Status.cs:line 77
   at Program.<>c__DisplayClass0_0.<<<Main>$>g__PurgeCommand|1>d.MoveNext() in D:\src\GitHub\DamianEdwards\dotnet-purge\src\dotnet-purge\Program.cs:line 92
--- End of stack trace from previous location ---
   at System.CommandLine.Invocation.InvocationPipeline.InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
```